### PR TITLE
Add a clean script

### DIFF
--- a/clean.js
+++ b/clean.js
@@ -1,0 +1,24 @@
+const CLI = require('neon-cli/lib/cli').default;
+const { join } = require('path');
+const { rmdir } = require('fs').promises;
+
+async function main() {
+  if (process.platform === 'win32') {
+    let cli = new CLI([,,'clean'], process.cwd());
+
+    await cli.exec();
+
+    await rmdir(join(process.cwd(), 'native', 'killer.exe'), {
+      recursive: true
+    });
+  }
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  })
+  .then(() => {
+    process.exit(0);
+  });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "node build.js",
+    "clean": "node clean.js",
     "install": "node-pre-gyp install --fallback-to-build=false || node build.js release",
     "test": "mocha -r ts-node/register \"test/**/*.test.ts\""
   },


### PR DESCRIPTION
A default yarn install will now try to get the binary from github so we may need to start clean. Also, it's handly when you want to build completely from scratch.

This delegates cleaning to the neon CLI for the most part, but also removes our custom `killer.exe` binary