### PR TITLE
Update workflow if to github-actions actor and bump patch

### DIFF
--- a/.changeset/many-schools-search.md
+++ b/.changeset/many-schools-search.md
@@ -1,0 +1,5 @@
+---
+"ctrlc-windows": patch
+---
+
+Fix release workflow

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'frontsidejack' }}
+    if: ${{ github.actor == 'github-actions' }}
     outputs:
       package_version: ${{ steps.package.outputs.version }}
     steps:


### PR DESCRIPTION
## Motivation
The bot that pushes the changeset commits for updating package versions is `github-actions` bot and not `frontsidejack`.

## Approach
- Changed if conditional to `actor == github-actions`. We still need that if statement so that it only runs when a changeset PR is merged.
- I bumped to another patch to trigger a new PR.
- This also means we have to always merge and never squash and merge for the changeset PRs.