### PR TITLE
Run release workflow on the condition that git tag does not exist

### DIFF
--- a/.changeset/hip-colts-scream.md
+++ b/.changeset/hip-colts-scream.md
@@ -1,0 +1,5 @@
+---
+"ctrlc-windows": patch
+---
+
+Fix release workflow v2

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -5,23 +5,35 @@ on:
       - 'v[0-9]+'
 
 jobs:
-  release:
-    name: Create Release
+  prechecks:
+    name: Check Existing Tags
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'github-actions' }}
     outputs:
+      tag_exists: ${{ steps.tags.outputs.current }}
       package_version: ${{ steps.package.outputs.version }}
     steps:
     - uses: actions/checkout@v2
     - name: Get package version
       run: echo "::set-output name=version::v$(node -p "require('./package.json').version")"
       id: package
+    - name: Check git tags
+      run: echo "::set-output name=current::$(git ls-remote --tags -q | grep ${{ steps.package.outputs.version }})"
+      id: tags
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: prechecks
+    if: ${{ !needs.prechecks.outputs.tag_exists }}
+    steps:
+    - uses: actions/checkout@v2
     - uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.package.outputs.version }}
-        release_name: Release ${{ steps.package.outputs.version }}
+        tag_name: ${{ needs.prechecks.outputs.package_version }}
+        release_name: Release ${{ needs.prechecks.outputs.package_version }}
+
   upload-binary:
     name: Upload Assets (node ${{ matrix.node-version }})
     runs-on: windows-latest
@@ -45,5 +57,5 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: build\stage\*\*.tar.gz
-        tag: ${{ needs.release.outputs.package_version }}
+        tag: ${{ needs.prechecks.outputs.package_version }}
         file_glob: true


### PR DESCRIPTION
## Motivation
I thought doing `if: github.actor == github-actions` would ensure that the release workflow will trigger only when we merge a changeset PR but unfortunately the github actor is based on who merges the PR (which makes sense because the person doing the merge is "creating" a commit on the head branch).

## Approach
Instead of relying on the github actor, I added a higher level job to check git tags.

The job will take the current package version and check to see if corresponding git tags exist and the remaining release workflow will only resume if no tags are returned. This ensures that the release workflow will run only when a package version is bumped (either manually or via changeset PR).

I added a patch changeset to trigger a new PR so I can merge that one too to test the full workflow. And I will manually create a fake release of `0.1.2` (current package version) so that the merge of THIS pull request does not go through the release cycle.