### PR TITLE
Fix environment variable scope for upload job

### DIFF
--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: prechecks
     if: ${{ !needs.prechecks.outputs.tag_exists }}
+    outputs:
+      package_version: ${{ needs.prechecks.outputs.package_version }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/create-release@v1
@@ -45,7 +47,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: volta-cli/action@v1
       with:
         node-version: ${{ matrix.node-version }}
@@ -57,5 +59,5 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: build\stage\*\*.tar.gz
-        tag: ${{ needs.prechecks.outputs.package_version }}
+        tag: ${{ needs.release.outputs.package_version }}
         file_glob: true


### PR DESCRIPTION
## Motivation
I was trying to access an environment variable that was not exposed in the last job.

## Approach
I re-ouput the package version variable from the second job so that the third job can access it.

Merging without changeset with v0.1.3 release and tag removed from github so it'll still trigger the upload jobs.