### PR TITLE
Fix binary releases

### DIFF
--- a/.changeset/binary-releases.md
+++ b/.changeset/binary-releases.md
@@ -1,0 +1,3 @@
+---
+"ctrlc-windows": minor
+---

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
 
-      - run: yarn install
+      - run: yarn install --ignore-scripts
+      - run: yarn build release
       - run: yarn test

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -52,8 +52,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         yarn-version: 1.22.5
-    - run: yarn install
-    - run: yarn neon build --release
+    - run: yarn install --ignore-scripts
+    - run: yarn build release
     - run: yarn node-pre-gyp package
     - uses: svenstaro/upload-release-action@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build
+dist
 native/target
 native/index.node
 native/killer.exe

--- a/build.js
+++ b/build.js
@@ -6,7 +6,7 @@ if (process.platform !== 'win32') {
 require('make-promises-safe');
 const CLI = require('neon-cli/lib/cli').default;
 const { exec } = require('child_process');
-const { copyFile } = require('fs').promises;
+const { copyFile, mkdir } = require('fs').promises;
 const { join } = require('path');
 
 const [,,profile] = process.argv;
@@ -21,8 +21,7 @@ async function main(argv) {
 
   // build the killer binary
   let profile = isRelease ? 'release' : 'debug';
-  const source = join(__dirname, 'native', 'target', profile, 'killer.exe');
-  const destination = join(__dirname, 'native', 'killer.exe');
+
   let cargo = ['cargo build', ...args, '--bin killer'].join(' ');
   let code = await new Promise((resolve, reject) => {
     let child = exec(cargo, {
@@ -37,7 +36,16 @@ async function main(argv) {
     process.exit(code || 1);
   }
 
-  await copyFile(source, destination);
+  await mkdir("dist", { recursive: true });
+
+  await copyFile(
+    join(__dirname, 'native', 'target', profile, 'killer.exe'),
+    join(__dirname, 'dist', 'killer.exe')
+  );
+  await copyFile(
+    join(__dirname, 'native', 'index.node'),
+    join(__dirname, 'dist', 'index.node')
+  );
 }
 
 main(process.argv)

--- a/clean.js
+++ b/clean.js
@@ -8,7 +8,7 @@ async function main() {
 
     await cli.exec();
 
-    await rmdir(join(process.cwd(), 'native', 'killer.exe'), {
+    await rmdir(join(process.cwd(), 'dist'), {
       recursive: true
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const { platform } = require('os');
 const { join } = require('path');
 
-const native = platform() === 'win32' ? require('../native') : require('./posix');
+const native = platform() === 'win32' ? require('../dist') : require('./posix');
 
 module.exports = {
   ctrlc(pid) {
@@ -9,7 +9,7 @@ module.exports = {
       // don't even attempt if the
       // process is not running
       if (process.kill(pid, 0)) {
-        native.ctrlc(pid, join(__dirname, "..", "native/killer.exe"));
+        native.ctrlc(pid, join(__dirname, "..", "dist/killer.exe"));
       }
     } catch (error) {
       if (error.code !== 'ESRCH') {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "files": [
     "build.js",
-    "native/index.node",
-    "native/killer*",
+    "native",
     "lib"
   ],
   "binary": {
@@ -18,15 +17,13 @@
     "host": "https://github.com/thefrontside/ctrlc-windows/releases/download/",
     "remote_path": "v{version}",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
-    "module_path": "./native",
-    "pkg_path": "."
+    "module_path": "./dist"
   },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^14.14.6",
     "neon-cli": "^0.5.0",
-    "node-pre-gyp": "amilajack/node-pre-gyp#neon-compat"
+    "node-pre-gyp": "^0.16.0"
   },
   "scripts": {
     "build": "node build.js",
@@ -37,6 +34,7 @@
   "devDependencies": {
     "@frontside/tsconfig": "^1.1.0",
     "@types/mocha": "^8.0.3",
+    "@types/node": "^14.14.6",
     "expect": "^26.6.2",
     "mocha": "^8.2.0",
     "ts-node": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,7 +1561,7 @@ mixme@^0.3.1:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
   integrity sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -1614,7 +1614,7 @@ nanoid@3.1.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
-needle@^2.2.1:
+needle@^2.5.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.2.tgz#cf1a8fce382b5a280108bba90a14993c00e4010a"
   integrity sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==
@@ -1648,20 +1648,21 @@ neon-cli@^0.5.0:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
-node-pre-gyp@amilajack/node-pre-gyp#neon-compat:
-  version "0.12.0"
-  resolved "https://codeload.github.com/amilajack/node-pre-gyp/tar.gz/2f08ba34f4941171387472e110a3cc51e2e62df4"
+node-pre-gyp@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.16.0.tgz#238fa540364784e5015dfcdba78da3937e18dbdc"
+  integrity sha512-4efGA+X/YXAHLi1hN8KaPrILULaUn2nWecFrn1k2I+99HpoyvcOGEbtcOxpDiUwPF2ZANMJDh32qwOUPenuR1g==
   dependencies:
     detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
+    mkdirp "^0.5.3"
+    needle "^2.5.0"
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"
     rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^4"
+    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -2368,7 +2369,7 @@ table-layout@^1.0.0:
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
 
-tar@^4:
+tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Motivation
-----------
The neon docs recommend using some weird fork of node-pre-gyp, but as we found out to our chagrin, it was generating binary tarbals that mixed the lib directory with the native directory.

Approach
----------
This completely side-steps the issue by copying built artifacts into the `dist/` directory and then using the normal un-forked node-pre-gyp npm package.