### PR TITLE
Add release workflow for NPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'v[0-9]+'
+
+jobs:
+  publish-releases:
+    name: Publish Releases
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish Releases
+      uses: thefrontside/actions/synchronize-with-npm@v1.6
+      with:
+        npm_publish: yarn publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
       with:
         npm_publish: yarn publish
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}


### PR DESCRIPTION
## Motivation
![Screen Shot 2020-11-09 at 2 03 18 PM](https://user-images.githubusercontent.com/29791650/98584778-5adeff00-2294-11eb-80b6-8942bdf846c2.png)

## Approach
- Added Jack's NPM token to secrets.
- Bumped down to 0.1.9 to manually publish.
- Successfully published 0.2.0 via github actions from `mk/publish` branch as a test.