### PR TITLE
Improve error messaging when killer fails

### DIFF
--- a/.changeset/better-error-messages.md
+++ b/.changeset/better-error-messages.md
@@ -1,0 +1,5 @@
+---
+"ctrlc-windows": patch
+---
+
+improved error messages when things go wrong

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -16,7 +16,7 @@ pub fn ctrlc(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         .arg(format!("{}", pid))
         .spawn() {
             Ok(child) => child,
-            Err(error) => return cx.throw_error(format!("unable to retain console: {}", error))
+            Err(error) => return cx.throw_error(format!("unable to spawn process to kill pid '{}'", error))
         };
 
     let status = killer.wait();
@@ -27,8 +27,8 @@ pub fn ctrlc(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         Ok(status) if status.success() => {
             Ok(cx.undefined())
         },
-        Ok(_) => cx.throw_error("killed with bad exit"),
-        Err(_) => cx.throw_error("bad")
+        Ok(_) => cx.throw_error(format!("unable to kill process with pid '{}'", pid)),
+        Err(error) => cx.throw_error(format!("{}", error))
     }
 }
 


### PR DESCRIPTION
When we were developing this originally, we just put in placeholders for the error messages since it was mostly about putting together the control flow. Now that we know we have what we want, this puts in error messaging that is a bit less cryptic.