### PR TITLE
Always skip build on non-windows platforms.

### DIFF
--- a/.changeset/skip-non-windows.md
+++ b/.changeset/skip-non-windows.md
@@ -1,0 +1,6 @@
+---
+"ctrlc-windows": patch
+---
+do not even invoke `node-pre-gyp` on non-windows platforms as part of
+the install script. This silences warnings that are printed to the
+console for npm

--- a/not-windows.js
+++ b/not-windows.js
@@ -1,0 +1,4 @@
+// succeeds only if this is not windows
+if (process.platform === 'win32') {
+  process.exit(1)
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "node build.js",
     "clean": "node clean.js",
-    "install": "node-pre-gyp install --fallback-to-build=false || node build.js release",
+    "install": "node not-windows.js || node-pre-gyp install --fallback-to-build=false || node build.js release",
     "test": "mocha -r ts-node/register \"test/**/*.test.ts\""
   },
   "devDependencies": {


### PR DESCRIPTION
Motivation
========

When installing ctrlc-windows on a non-windows platform, the `node-pre-gyp` invocation fails because a pre-compiled binary does not exist. This isn't much of a problem since the fallback behavior is to run the `build.js` script which skips non-windows platforms entirely. In other words, the command is roughly

```sh
$ node-pre-gyp || node build.js
```

And it succeeds, so `yarn` does not bother you with the fact that `node-pre-gyp` failed. However, when using `npm`, not yarn, the `stderr` is printed to the console always, even though the package install script succeeds overall. We want this warning to not be displayed with either package manager.

Approach
=======

This adds a `not-windows.js` script that exits successfully for all non-windows platforms that can be used to effectively "short-circuit" the install script if we're not running on windows. Not only does this silence the warning, but also has the added benefit that `node-pre-gyp` is never invoked and so the network is never queried for the binaries that will never be found for non-windows systems.

In other words, the package install script is now:

```sh
$ node not-windows.js || node-pre-gyp || node build.js
```