### PR TITLE
Include `not-windows.js` in tarball

### DIFF
--- a/.changeset/fix-install-script.md
+++ b/.changeset/fix-install-script.md
@@ -1,0 +1,5 @@
+---
+"ctrlc-windows": patch
+---
+Include the `not-windows.js` file to short circuit the build on
+non-windows platforms.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/thefrontside/ctrlc-windows.git"
   },
   "files": [
+    "not-windows.js",
     "build.js",
     "native",
     "lib"


### PR DESCRIPTION
Motivation
-----------

The NPM `files` distribution did not include the script invoked by install to short circuit in the event that we're not running on windows.


Approach
----------
This adds the `not-windows.js` file to the distribution tarball.
