### PR TITLE
Add node 15 and 16 for binary release workflow

### DIFF
--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -42,7 +42,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        node-version: ['10', '12', '14']
+        node-version: ['10', '12', '14', '15', '16']
     steps:
     - uses: actions-rs/toolchain@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - 21ce6a2: Include the `not-windows.js` file to short circuit the build on
   non-windows platforms.
+- 3add0af: Add node 15 and 16 for the binary release workflow
 
 ## 1.0.2
 


### PR DESCRIPTION
## Motivation

To resolve #21.

## Approach

Added `15` and `16` to the `node-version` matrix.

No changeset because we're not making changes to the package itself.