### PR TITLE
Upload node 15 and 16 binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,12 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.platform }}
-    name: ${{ matrix.platform }} test
+    name: ${{ matrix.platform }} test node@${{ matrix.node }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest]
-      fail-fast: false
+        node: [10, 12, 14, 16]
     steps:
       - uses: actions-rs/toolchain@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ctrlc-windows
 
+## 1.0.4
+
+### Patch Changes
+
+- 58deed0: Fix: Upload binaries for node 15 and 16
+
 ## 1.0.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctrlc-windows",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Send CTRL-C to a process on Windows",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## Motivation

To fix and oversight on node 15/16 binaries not being uploaded.

## Approach

The current `upload-binaries` files gets uploaded if it confirms that the corresponding git tag doesn't exist yet. We were thinking of modifying the current v1.0.3 release but I've also been told that's not a good idea.