### PR TITLE
Upload node 16 binary (attempt #2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
           command: yarn test
 
 jobs:
-  test:
+  test2:
     executor: << parameters.executor >>
     parameters:
       executor:
@@ -38,9 +38,9 @@ jobs:
       - test
 
 workflows:
-  test:
+  testworkflow:
     jobs:
-      - test:
+      - test2:
           name: "test-windows-node-1-2-3"
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
     parameters:
       executor:
         type: <<parameters.os>>
+        default: "win"
     steps:
       - checkout
       - yarn_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,10 @@ commands:
 
 jobs:
   test2:
-    executor: << parameters.executor >>
+    executor: <<parameters.executor>>
     parameters:
       executor:
-        type: << parameters.os >>
+        type: <<parameters.os>>
     steps:
       - checkout
       - yarn_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,5 +45,9 @@ workflows:
           name: "test-windows-node-1-2-3"
           matrix:
             parameters:
-              os: [win]
-              node-versions: ["10.9.0", "11.9.0", "12.9.1"]
+              os: 
+                - win
+              node-versions:
+                - "10.9.0"
+                - "11.9.0"
+                - "12.9.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
+executors:
+  linux:
+    docker:
+      - image: circleci/node:15-browsers
+
+commands:
+  yarn_install:
+    steps:
+      - run:
+          name: Installing dependencies
+          command: yarn install --frozen-lockfile --ignore-scripts
+  build:
+    steps:
+      - run:
+          name: Build release binaries
+          command: yarn build release
+  test:
+    steps:
+      - run:
+          name: Run test
+          command: yarn test
+
+jobs:
+  test:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        type: << parameters.os >>
+    steps:
+      - checkout
+      - yarn_install
+      - build
+      - test
+
+workflows:
+  test:
+    jobs:
+      - test:
+          name: "test-windows-node-1-2-3"
+          matrix:
+            parameters:
+              os: [win]
+              node-versions: ["10.9.0", "11.9.0", "12.9.1"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        node-version: ['10', '12', '14', '15', '16']
+        node-version: ['10', '12', '14', '16']
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       # - run: yarn build release
       #   env:
       #     RUST_BACKTRACE: 1
-      - run: neon build --release
+      - run: yarn neon build --release
       - run: cargo build --release --bin killer
       - run: |
           cp native/target/release/killer.exe dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           yarn-version: 1.22.5
       - run: yarn install --ignore-scripts
-      - run: yarn build release
-        env:
-          RUST_BACKTRACE: 1
+      # - run: yarn build release
+      #   env:
+      #     RUST_BACKTRACE: 1
+      - run: neon build --release
+      - run: cargo build --release --bin killer
+      - run: |
+          cp native/target/release/killer.exe dist
+          cp native/index.node dist
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,4 @@ jobs:
           yarn-version: 1.22.5
       - run: yarn install --ignore-scripts
       - run: yarn build release
-        env:
-          RUST_BACKTRACE: 1
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn config set python python2.7
-      - run: yarn config set msvs_version 2015
+      - run: yarn global add --production windows-build-tools
       - run: yarn install --ignore-scripts
       - run: yarn build release
       #   env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     name: ${{ matrix.platform }} test node@${{ matrix.node-version }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
-        node-version: ['10', '12', '14', '16']
+        platform: [windows-latest]
+        node-version: ['16']
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,6 @@ jobs:
           yarn-version: 1.22.5
       - run: yarn install --ignore-scripts
       - run: yarn build release
+        env:
+          RUST_BACKTRACE: 1
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   pull_request:
     branches:
-      - 'v[0-9]+'
+      - "v[0-9]+"
 
 jobs:
   test:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [windows-latest]
-        node-version: ['12', '14', '16']
+        node-version: ["12", "14", "16"]
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - run: yarn config set python python2.7
+      - run: yarn config set msvs_version 2015
       - run: yarn install --ignore-scripts
       - run: yarn build release
       #   env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,23 @@ jobs:
     strategy:
       matrix:
         platform: [windows-latest]
-        node-version: ['16']
+        node-version: ['12', '14', '16']
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/checkout@v1
-      - uses: volta-cli/action@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          yarn-version: 1.22.5
       - run: yarn install --ignore-scripts
-      # - run: yarn build release
+      - run: yarn build release
       #   env:
       #     RUST_BACKTRACE: 1
-      - run: yarn neon build --release
-      - run: cargo build --release --bin killer
-      - run: |
-          cp native/target/release/killer.exe dist
-          cp native/index.node dist
+      # - run: yarn neon build --release
+      # - run: cargo build --release --bin killer
+      # - run: |
+      #     cp native/target/release/killer.exe dist
+      #     cp native/index.node dist
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.platform }}
-    name: ${{ matrix.platform }} test
+    name: ${{ matrix.platform }} test node@{{ matrix.node-version }}
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
+        node-version: ['10', '12', '14', '15', '16']
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1
@@ -19,7 +20,9 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
-
+        with:
+          node-version: ${{ matrix.node-version }}
+          yarn-version: 1.22.5
       - run: yarn install --ignore-scripts
       - run: yarn build release
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.platform }}
-    name: ${{ matrix.platform }} test node@{{ matrix.node-version }}
+    name: ${{ matrix.platform }} test node@${{ matrix.node-version }}
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -1,63 +1,24 @@
 name: Upload Binaries
-on:
-  push:
-    branches:
-      - 'v[0-9]+'
+
+on: pull_request
 
 jobs:
-  prechecks:
-    name: Check Existing Tags
-    runs-on: ubuntu-latest
-    outputs:
-      tag_exists: ${{ steps.tags.outputs.current }}
-      package_version: ${{ steps.package.outputs.version }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Get package version
-      run: echo "::set-output name=version::v$(node -p "require('./package.json').version")"
-      id: package
-    - name: Check git tags
-      run: echo "::set-output name=current::$(git ls-remote --tags -q | grep ${{ steps.package.outputs.version }})"
-      id: tags
-
-  release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    needs: prechecks
-    if: ${{ !needs.prechecks.outputs.tag_exists }}
-    outputs:
-      package_version: ${{ needs.prechecks.outputs.package_version }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ needs.prechecks.outputs.package_version }}
-        release_name: Release ${{ needs.prechecks.outputs.package_version }}
-
   upload-binary:
     name: Upload Assets (node ${{ matrix.node-version }})
     runs-on: windows-latest
-    needs: release
     strategy:
       matrix:
         node-version: ['10', '12', '14', '15', '16']
+      fail-fast: false
     steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - uses: actions/checkout@v2
-    - uses: volta-cli/action@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-        yarn-version: 1.22.5
-    - run: yarn install --ignore-scripts
-    - run: yarn build release
-    - run: yarn node-pre-gyp package
-    - uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build\stage\*\*.tar.gz
-        tag: ${{ needs.release.outputs.package_version }}
-        file_glob: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          yarn-version: 1.22.5
+      - run: yarn install --ignore-scripts
+      - run: yarn build release
+      - run: yarn node-pre-gyp package

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -1,15 +1,49 @@
 name: Upload Binaries
 
-on: pull_request
+on:
+  push:
+    branches:
+      - 'v[0-9]+'
 
 jobs:
+  prechecks:
+    name: Check Existing Tags
+    runs-on: ubuntu-latest
+    outputs:
+      tag_exists: ${{ steps.tags.outputs.current }}
+      package_version: ${{ steps.package.outputs.version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get package version
+      run: echo "::set-output name=version::v$(node -p "require('./package.json').version")"
+      id: package
+    - name: Check git tags
+      run: echo "::set-output name=current::$(git ls-remote --tags -q | grep ${{ steps.package.outputs.version }})"
+      id: tags
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: prechecks
+    if: ${{ !needs.prechecks.outputs.tag_exists }}
+    outputs:
+      package_version: ${{ needs.prechecks.outputs.package_version }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ needs.prechecks.outputs.package_version }}
+        release_name: Release ${{ needs.prechecks.outputs.package_version }}
+
   upload-binary:
     name: Upload Assets (node ${{ matrix.node-version }})
     runs-on: windows-latest
+    needs: release
     strategy:
       matrix:
         node-version: ['10', '12', '14', '16']
-      fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1
         with:
@@ -22,3 +56,9 @@ jobs:
       - run: yarn install --ignore-scripts
       - run: yarn build release
       - run: yarn node-pre-gyp package
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build\stage\*\*.tar.gz
+          tag: ${{ needs.release.outputs.package_version }}
+          file_glob: true

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: ['10', '12', '14', '15', '16']
+        node-version: ['10', '12', '14', '16']
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ctrlc-windows
 
+## 1.0.5
+
+### Patch Changes
+
+- 02d3ec1: Fix: Add node 16 to test and upload workflow (node 15 omitted (see PR #28))
+
 ## 1.0.3
 
 ### Patch Changes

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -17,9 +17,9 @@ checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cslice"
@@ -50,42 +50,42 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "neon"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1314e1a7a6375ddfab87906f98e5a848649c5a88d7d118e9d603c12440964e"
+checksum = "7567f84d17e451c0f6c4e6799a4702294b97debd2db007ab1453f85714bfcb80"
 dependencies = [
  "cslice",
  "neon-build",
  "neon-runtime",
  "semver",
- "winapi",
+ "smallvec",
 ]
 
 [[package]]
 name = "neon-build"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a7bb825db76fd7b73956ea39329b92bc599adc8b71e1675908d9062c6dae69"
+checksum = "5fd3ca70b6bc64f337131b1ec6181adadcf6f0df30ec99ee6cd25652bcb6c831"
 dependencies = [
- "cfg-if",
  "neon-sys",
 ]
 
 [[package]]
 name = "neon-runtime"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e7dcc582b1c713f58f0b092b3f11de3ac94b2b8d78ea4b658b8990bfb3412c"
+checksum = "5a1a13a60640ef807aac092a2a4ae08bc9bc701b516bd39cc54cfe441935b3d3"
 dependencies = [
  "cfg-if",
  "neon-sys",
+ "smallvec",
 ]
 
 [[package]]
 name = "neon-sys"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41690bb07b1673ec8073f5c64dc041ab997d56a5d3cb2cbcc6dbfb7416c135e"
+checksum = "94fca3a6fcf36b82a80f9897afb211264aa1e924b9b157c75e073a0f919c43e0"
 dependencies = [
  "cc",
  "regex",
@@ -123,6 +123,12 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "thread_local"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -12,8 +12,8 @@ name = "ctrlc_windows"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.5.0"
+neon-build = "0.8.1"
 
 [dependencies]
-neon = "0.5.0"
+neon = "0.8.1"
 winapi = { version = "0.3.9", features = ["consoleapi"] }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "dependencies": {
-    "neon-cli": "^0.5.0",
+    "neon-cli": "^0.8.1",
     "node-pre-gyp": "^0.16.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctrlc-windows",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Send CTRL-C to a process on Windows",
   "main": "lib/index.js",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,7 +793,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -1561,7 +1561,7 @@ mixme@^0.3.1:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
   integrity sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==
 
-mkdirp@^0.5.0, mkdirp@^0.5.3:
+mkdirp@^0.5.0, mkdirp@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -1614,10 +1614,10 @@ nanoid@3.1.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
-needle@^2.5.0:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.2.tgz#cf1a8fce382b5a280108bba90a14993c00e4010a"
-  integrity sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==
+needle@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
+  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
   dependencies:
     debug "^3.2.6"
     iconv-lite "^0.4.4"
@@ -1628,10 +1628,10 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-neon-cli@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.5.1.tgz#a8568f64878687c7c95e1aad0ff99256b3daf65f"
-  integrity sha512-j8y4BvCoKn+sBabMbFe4on5ZZkuJOvBRNdPnE61etWixQFWCaBJOa0ZUH9UQM1+2FfPFDQlHNb/alpzSWz+b9w==
+neon-cli@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.8.1.tgz#30cbb5d462f5b4b182764df30b4f78265cfffb2c"
+  integrity sha512-Zd6azCP05DwwwevLU3oSuuTbFAYULius4ehbulTiBxl/jAGwZ5GYGv/cM5ekNX00crqr5Qt9c4uFpOnbhgIgRQ==
   dependencies:
     chalk "^4.1.0"
     command-line-args "^5.1.1"
@@ -1648,23 +1648,23 @@ neon-cli@^0.5.0:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
-node-pre-gyp@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.16.0.tgz#238fa540364784e5015dfcdba78da3937e18dbdc"
-  integrity sha512-4efGA+X/YXAHLi1hN8KaPrILULaUn2nWecFrn1k2I+99HpoyvcOGEbtcOxpDiUwPF2ZANMJDh32qwOUPenuR1g==
+node-pre-gyp@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.17.0.tgz#5af3f7b4c3848b5ed00edc3d298ff836daae5f1d"
+  integrity sha512-abzZt1hmOjkZez29ppg+5gGqdPLUuJeAEwVPtHYEJgx0qzttCbcKFpxrCQn2HYbwCv2c+7JwH4BgEzFkUGpn4A==
   dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.3"
-    needle "^2.5.0"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
+    detect-libc "^1.0.3"
+    mkdirp "^0.5.5"
+    needle "^2.5.2"
+    nopt "^4.0.3"
+    npm-packlist "^1.4.8"
+    npmlog "^4.1.2"
+    rc "^1.2.8"
+    rimraf "^2.7.1"
+    semver "^5.7.1"
+    tar "^4.4.13"
 
-nopt@^4.0.1:
+nopt@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
   integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
@@ -1699,7 +1699,7 @@ npm-normalize-package-bin@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
   integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
-npm-packlist@^1.1.6:
+npm-packlist@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -1715,7 +1715,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -1962,7 +1962,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-rc@^1.2.7:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -2078,7 +2078,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^2.6.1:
+rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -2129,7 +2129,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -2369,7 +2369,7 @@ table-layout@^1.0.0:
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
 
-tar@^4.4.2:
+tar@^4.4.13:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,7 +793,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-detect-libc@^1.0.3:
+detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -1561,7 +1561,7 @@ mixme@^0.3.1:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
   integrity sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==
 
-mkdirp@^0.5.0, mkdirp@^0.5.5:
+mkdirp@^0.5.0, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -1614,7 +1614,7 @@ nanoid@3.1.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
-needle@^2.5.2:
+needle@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
   integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
@@ -1648,23 +1648,23 @@ neon-cli@^0.8.1:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
-node-pre-gyp@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.17.0.tgz#5af3f7b4c3848b5ed00edc3d298ff836daae5f1d"
-  integrity sha512-abzZt1hmOjkZez29ppg+5gGqdPLUuJeAEwVPtHYEJgx0qzttCbcKFpxrCQn2HYbwCv2c+7JwH4BgEzFkUGpn4A==
+node-pre-gyp@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.16.0.tgz#238fa540364784e5015dfcdba78da3937e18dbdc"
+  integrity sha512-4efGA+X/YXAHLi1hN8KaPrILULaUn2nWecFrn1k2I+99HpoyvcOGEbtcOxpDiUwPF2ZANMJDh32qwOUPenuR1g==
   dependencies:
-    detect-libc "^1.0.3"
-    mkdirp "^0.5.5"
-    needle "^2.5.2"
-    nopt "^4.0.3"
-    npm-packlist "^1.4.8"
-    npmlog "^4.1.2"
-    rc "^1.2.8"
-    rimraf "^2.7.1"
-    semver "^5.7.1"
-    tar "^4.4.13"
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.3"
+    needle "^2.5.0"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
 
-nopt@^4.0.3:
+nopt@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
   integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
@@ -1699,7 +1699,7 @@ npm-normalize-package-bin@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
   integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
-npm-packlist@^1.4.8:
+npm-packlist@^1.1.6:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -1715,7 +1715,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.1.2:
+npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -1962,7 +1962,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-rc@^1.2.8:
+rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -2078,7 +2078,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^2.7.1:
+rimraf@^2.6.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -2129,7 +2129,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -2369,7 +2369,7 @@ table-layout@^1.0.0:
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
 
-tar@^4.4.13:
+tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
## Motivation

#25 did not turn out the way we had hoped

## Approach (Updated ✨)

- The tests were passing in #25 but we weren't actually using the node versions in the matrix (via volta). So I fixed that in the test workflow and ~I'm also running the upload workflow but without any of the prechecks and without creating a release nor uploading the binaries to see if it actually builds using `node-pre-gyp`~.
  - See successful build of 10, 12, 14, 16 [here](https://github.com/thefrontside/ctrlc-windows/actions/runs/838560764)
    - Upload workflow was reverted with 16 added so that it runs on push on main branches again after confirming it works in this PR
- Bumped `neon`, `neon-build`, and `neon-cli` to latest in order to build in node 16.
- Updated CHANGELOG and bumped package to 1.0.5 to trigger upload and release.

## TODOs
- ⚠️ The windows tests in Github Actions will sometimes fail which requires me to re-run the test workflow until it passes.
  - The windows tests from commit [a04d4f5](https://github.com/thefrontside/ctrlc-windows/pull/28/commits/a04d4f5460e9ebd1b3f4d7a48e572937983de9c1) ran [successfully](https://github.com/thefrontside/ctrlc-windows/actions/runs/838560765)
  - And the windows tests for the last commit is failing even though the only changes are to a [separate workflow](https://github.com/thefrontside/ctrlc-windows/pull/28/commits/f70f90da50b9d4875e9e0348ac4d64c0ff8d5336), the [package version of `ctrlc-windows`](https://github.com/thefrontside/ctrlc-windows/pull/28/commits/02d3ec159cc1d8fe1264cf957104861e3a903aac), and the [CHANGELOG](https://github.com/thefrontside/ctrlc-windows/pull/28/commits/7b52d55e1a30e75b7fe637f41fa0262bd0867efb).