### PR TITLE
Fix broken release with release of 1.0.5

### DIFF
--- a/.changeset/serious-weeks-invite.md
+++ b/.changeset/serious-weeks-invite.md
@@ -1,0 +1,5 @@
+---
+"ctrlc-windows": patch
+---
+
+Remove node 15 and 16 in release to undo broken 1.0.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.platform }}
-    name: ${{ matrix.platform }} test
+    name: ${{ matrix.platform }} test node@${{ matrix.node-version }}
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
+        node-version: ['10', '12', '14']
       fail-fast: false
     steps:
       - uses: actions-rs/toolchain@v1
@@ -19,7 +20,9 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
-
+        with:
+          node-version: ${{ matrix.node-version }}
+          yarn-version: 1.22.5
       - run: yarn install --ignore-scripts
       - run: yarn build release
       - run: yarn test

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -42,7 +42,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        node-version: ['10', '12', '14', '15', '16']
+        node-version: ['10', '12', '14']
     steps:
     - uses: actions-rs/toolchain@v1
       with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctrlc-windows",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Send CTRL-C to a process on Windows",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## Motivation

PR #25 did not upload the correct binaries and so we had to revert it in #27 but #25 actually published and created an empty github release so this PR is to properly build and upload binaries for node 10, 12, and 14.

## Approach

- Removed node 15 and 16 from upload workflow
- Added matrix of node versions for the test workflow
- Bumped package to 1.0.4 in order for the changeset file to be able to bump to 1.0.5
- ~Updated changelog and bumped package version to 1.0.5~