### PR TITLE
Use global NPM Token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
           npm_publish: yarn publish
         env:
           GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation

I switch this repository to use our global NPM token.

## Approach

Switch to use NPM_TOKEN
