### PR TITLE
bump sync-with-npm action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - run: yarn install
       - run: yarn build
       - name: Publish Releases
-        uses: thefrontside/actions/synchronize-with-npm@v1.9
+        uses: thefrontside/actions/synchronize-with-npm@v2
         with:
           npm_publish: yarn publish
         env:


### PR DESCRIPTION
## Motivation

The sync-with-npm action failed as it still used the container image on v1. It appeared that it on the latest, but there is a v2 branch that seems the backstage repo uses. 

## Approach

Set to v2.
