### PR TITLE
Add aarch64 binaries

### DIFF
--- a/.changeset/blue-papayas-push.md
+++ b/.changeset/blue-papayas-push.md
@@ -1,0 +1,5 @@
+---
+"ctrlc-windows": minor
+---
+
+Added support for arm64.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,12 @@ jobs:
     name: Publish Releases
     runs-on: windows-latest
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.63
+      - name: Install Rust Toolchain
+        run: |
+          rustup install 1.63.0
+          rustup default 1.63.0
+          rustup target add x86_64-pc-windows-msvc
+          rustup target add aarch64-pc-windows-msvc
       - uses: volta-cli/action@v3
         with:
           node-version: 14
@@ -22,7 +25,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/checkout@v3
       - run: yarn install
-      - run: yarn build
+      - run: yarn build --arch=arm64
+      - run: yarn build --arch=x64
       - name: Publish Releases
         uses: thefrontside/actions/synchronize-with-npm@v2
         with:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
-const { platform } = require("os");
+const { platform, arch } = require("os");
 const { join } = require("path");
+
+const archDistDirName = arch() === "arm64" ? "arm64" : "x64";
 
 const native =
   platform() === "win32"
-    ? require("../dist/ctrlc-windows.node")
+    ? require(`../dist/${archDistDirName}/ctrlc-windows.node`)
     : require("./posix");
 
 module.exports = {
@@ -12,7 +14,8 @@ module.exports = {
       // don't even attempt if the
       // process is not running
       if (process.kill(pid, 0)) {
-        native.ctrlc(pid, join(__dirname, "..", "dist/process-killer.exe"));
+        const processKillerPath = join(__dirname, "..", `dist/${archDistDirName}/process-killer.exe`);
+        native.ctrlc(pid, processKillerPath);
       }
     } catch (error) {
       if (error.code !== "ESRCH") {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "triples": {
       "defaults": false,
       "additional": [
+        "aarch64-pc-windows-msvc",
         "x86_64-pc-windows-msvc"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "scripts": {
-    "build": "napi build --release && rimraf dist && mkdirp dist && mv ctrlc-windows.node dist && mv ./target/release/process-killer dist",
+    "build": "node ./scripts/build.js --release",
     "test": "mocha -r ts-node/register \"test/**/*.test.ts\"",
-    "build:debug": "napi build --platform",
+    "build:debug": "node ./scripts/build.js",
     "format": "run-p format:prettier format:rs",
     "format:prettier": "prettier . -w",
     "format:rs": "cargo fmt",
@@ -44,7 +44,8 @@
     "mocha": "^10.0.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "yargs": "^17.7.2"
   },
   "volta": {
     "node": "14.20.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const os = require("os");
+const path = require("path");
+const mkdirp = require("mkdirp");
+const fs = require("fs");
+
+const { arch, release } = require("yargs")
+  .usage(
+    "$0",
+    "build for the given architecture",
+    (yargs) => {
+      yargs.option("r", {
+        alias: "release",
+        describe: "make a release build",
+        boolean: true,
+        require: false,
+        default: false,
+      });
+      yargs.option("a", {
+        alias: "arch",
+        describe: "target architecture, defaults to host architecture",
+        type: "string",
+        default: os.arch(),
+        require: false,
+      });
+    },
+  )
+  .help("help").argv;
+
+if (os.platform() !== "win32") {
+  console.log("Skipping native build on non-Windows platform");
+  process.exit(0);
+}
+
+const targetTriple = arch === "arm64" ?
+  "aarch64-pc-windows-msvc" : "x86_64-pc-windows-msvc";
+
+const rootDir = path.resolve(__dirname, "..");
+const archDistDir = path.join(rootDir, "dist", arch);
+
+const buildCommand = `yarn napi build --target=${targetTriple}${release ? " --release" : ""}`;
+console.log(buildCommand);
+execSync(buildCommand, { stdio: "inherit" });
+
+console.log("Moving artifacts to dist directory");
+mkdirp.sync(archDistDir);
+
+fs.renameSync(
+  path.join(rootDir, "target", targetTriple, release ? "release" : "debug", "process-killer.exe"),
+  path.join(archDistDir, "process-killer.exe"),
+);
+
+fs.renameSync(
+  path.join(rootDir, 'ctrlc-windows.node'),
+  path.join(archDistDir, 'ctrlc-windows.node'),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -2394,7 +2403,7 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
@@ -2451,6 +2460,19 @@ yargs@^17.1.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Motivation

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

Implements https://github.com/thefrontside/ctrlc-windows/issues/46.

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

The native binaries for both arm64 and x64 are shipped in the package's dist directory:
```
dist
├── arm64
│   ├── ctrlc-windows.node
│   └── process-killer.exe
└── x64
    ├── ctrlc-windows.node
    └── process-killer.exe
``` 

Previously, only x64 binaries were available. Also:

* `index.js` loads the module for the correct architecture at runtime.
* A JS build script runs `napi build` for a particular architecture then moves the artifacts to the correct path in dist. By default, this builds for the host system.
* CI is updated to build for both platforms.

A package created from a slightly modified version of the CI in this repo on both platforms, but I've not been able to test the full release CI on my fork.

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

I suggested using napi-rs's default build approach in https://github.com/thefrontside/ctrlc-windows/issues/46. This would publish two additional platform-specific packages to NPM: `ctrlc-windows-x64` and `ctrlc-windows-arm64`. This turned out to be quite hard, partly due to the additional process-killer.exe binary. I couldn't get napi-rs's CLI to copy it to the correct path, meaning we'd need a build script anyway.

The downside is shipping an extra 180KB in the package. Hopefully this is worth it to avoid the extra build and consumer complexity.